### PR TITLE
Add Egger interval diagnostics

### DIFF
--- a/man/maive.Rd
+++ b/man/maive.Rd
@@ -37,6 +37,8 @@ of PET, PEESE, PET-PEESE, not available for fixed effects): 0 no, 1 yes.}
   \item pub bias p-value: p-value of test for publication bias / p-hacking based on instrumented FAT
   \item egger_coef: Egger Coefficient (PET estimate)
   \item egger_se: Egger Standard Error (PET standard error)
+  \item egger_boot_ci: Confidence interval for the Egger coefficient using the selected resampling scheme
+  \item egger_ar_ci: Anderson-Rubin confidence interval for the Egger coefficient (when available)
   \item is_quadratic_fit: Details on quadratic selection and slope behaviour
   \item boot_result: Boot result
   \item slope_coef: Slope coefficient

--- a/tests/testthat/test-maive_egger_ci.R
+++ b/tests/testthat/test-maive_egger_ci.R
@@ -1,0 +1,51 @@
+test_that("maive reports Egger bootstrap and AR intervals when eligible", {
+  dat <- data.frame(
+    bs = c(0.4, 0.6, 0.55, 0.5, 0.52, 0.49),
+    sebs = c(0.2, 0.18, 0.22, 0.19, 0.21, 0.2),
+    Ns = c(80, 95, 90, 85, 88, 92),
+    study_id = c(1, 1, 2, 2, 3, 3)
+  )
+
+  res <- maive(
+    dat = dat,
+    method = 1,
+    weight = 0,
+    instrument = 1,
+    studylevel = 2,
+    SE = 0,
+    AR = 1
+  )
+
+  expect_true(is.numeric(res$egger_boot_ci))
+  expect_length(res$egger_boot_ci, 2)
+  expect_equal(sort(names(res$egger_boot_ci)), c("lower", "upper"))
+
+  expect_true(is.numeric(res$egger_ar_ci))
+  expect_length(res$egger_ar_ci, 2)
+  expect_equal(sort(names(res$egger_ar_ci)), c("lower", "upper"))
+})
+
+test_that("maive returns NA Egger AR interval when AR is disabled", {
+  dat <- data.frame(
+    bs = c(0.4, 0.6, 0.55, 0.5, 0.52, 0.49),
+    sebs = c(0.2, 0.18, 0.22, 0.19, 0.21, 0.2),
+    Ns = c(80, 95, 90, 85, 88, 92),
+    study_id = c(1, 1, 2, 2, 3, 3)
+  )
+
+  res <- maive(
+    dat = dat,
+    method = 1,
+    weight = 0,
+    instrument = 1,
+    studylevel = 2,
+    SE = 0,
+    AR = 0
+  )
+
+  expect_true(is.numeric(res$egger_boot_ci))
+  expect_length(res$egger_boot_ci, 2)
+  expect_equal(sort(names(res$egger_boot_ci)), c("lower", "upper"))
+
+  expect_identical(res$egger_ar_ci, "NA")
+})

--- a/tests/testthat/test-maive_regression_equivalence.R
+++ b/tests/testthat/test-maive_regression_equivalence.R
@@ -47,6 +47,12 @@ test_that("maive results match baseline fixtures", {
     actual <- do.call(maive, c(list(dat = scenario$data), scenario$args))
     expected <- baseline[[scenario_name]]
 
+    # These keys are not present in the baseline results used
+    # at the time of writing this test, so we drop them here.
+    drop_keys <- c("egger_boot_ci", "egger_ar_ci")
+    actual[drop_keys] <- NULL
+    expected[drop_keys] <- NULL
+
     expect_equal(
       strip_names(actual),
       strip_names(expected),


### PR DESCRIPTION
## Summary
- add shared confidence-interval helper for coefficient inference that reuses bootstrap or sandwich estimates
- expose bootstrap and Anderson–Rubin confidence intervals for the Egger slope alongside existing Egger statistics
- document the new return fields in the `maive` reference

## Testing
- `Rscript -e "devtools::test()"` *(fails: Rscript not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d123ef3158832a9cd101b9e925b6e0