### PR TITLE
Fix bootstrap CI naming for degenerate outputs

### DIFF
--- a/R/maivefunction.r
+++ b/R/maivefunction.r
@@ -403,8 +403,7 @@ maive_prepare_confidence_interval <- function(model, coef_index, estimate, se, b
     if (is.null(ci_row)) {
       ci_row <- boot_ci[coef_index, ]
     }
-    ci_vals <- as.numeric(ci_row)
-    names(ci_vals) <- c("lower", "upper")
+    ci_vals <- maive_normalize_ci_bounds(ci_row)
     ci_vals
   } else {
     crit <- stats::qnorm(1 - alpha / 2)
@@ -412,6 +411,22 @@ maive_prepare_confidence_interval <- function(model, coef_index, estimate, se, b
     names(ci_vals) <- c("lower", "upper")
     ci_vals
   }
+}
+
+maive_normalize_ci_bounds <- function(ci_row) {
+  ci_vals <- as.numeric(ci_row)
+  if (length(ci_vals) == 0) {
+    ci_vals <- rep(NA_real_, 2L)
+  } else if (length(ci_vals) == 1) {
+    ci_vals <- rep(ci_vals[1], 2L)
+  } else if (length(ci_vals) > 2) {
+    ci_vals <- ci_vals[seq_len(2L)]
+  }
+  if (length(ci_vals) < 2) {
+    ci_vals <- c(ci_vals, rep(NA_real_, 2L - length(ci_vals)))
+  }
+  names(ci_vals) <- c("lower", "upper")
+  ci_vals
 }
 
 #' @keywords internal

--- a/tests/testthat/test-maive_confidence_interval.R
+++ b/tests/testthat/test-maive_confidence_interval.R
@@ -1,0 +1,40 @@
+test_that("maive_prepare_confidence_interval handles degenerate bootstrap ci", {
+  model <- stats::lm(effect ~ 1, data = data.frame(effect = 1:3))
+
+  base_args <- list(
+    model = model,
+    coef_index = 1,
+    estimate = unname(coef(model)[1]),
+    se = 1,
+    alpha = 0.05
+  )
+
+  expect_silent({
+    ci <- do.call(
+      MAIVE:::maive_prepare_confidence_interval,
+      c(base_args, list(boot_result = list(boot_ci = matrix(NA_real_, nrow = 1, ncol = 1))))
+    )
+    expect_identical(names(ci), c("lower", "upper"))
+    expect_true(all(is.na(ci)))
+  })
+
+  expect_silent({
+    ci <- do.call(
+      MAIVE:::maive_prepare_confidence_interval,
+      c(base_args, list(boot_result = list(boot_ci = matrix(0.5, nrow = 1, ncol = 1))))
+    )
+    expect_identical(names(ci), c("lower", "upper"))
+    expect_equal(ci, rep(0.5, 2))
+  })
+
+  expect_silent({
+    boot_ci <- matrix(c(0.2, 0.8), nrow = 1)
+    dimnames(boot_ci) <- list(NULL, NULL)
+    ci <- do.call(
+      MAIVE:::maive_prepare_confidence_interval,
+      c(base_args, list(boot_result = list(boot_ci = boot_ci)))
+    )
+    expect_identical(names(ci), c("lower", "upper"))
+    expect_equal(ci, c(0.2, 0.8))
+  })
+})

--- a/tests/testthat/test-maive_confidence_interval.R
+++ b/tests/testthat/test-maive_confidence_interval.R
@@ -24,7 +24,7 @@ test_that("maive_prepare_confidence_interval handles degenerate bootstrap ci", {
       c(base_args, list(boot_result = list(boot_ci = matrix(0.5, nrow = 1, ncol = 1))))
     )
     expect_identical(names(ci), c("lower", "upper"))
-    expect_equal(ci, rep(0.5, 2))
+    expect_equal(ci, setNames(rep(0.5, 2), c("lower", "upper")))
   })
 
   expect_silent({
@@ -35,6 +35,6 @@ test_that("maive_prepare_confidence_interval handles degenerate bootstrap ci", {
       c(base_args, list(boot_result = list(boot_ci = boot_ci)))
     )
     expect_identical(names(ci), c("lower", "upper"))
-    expect_equal(ci, c(0.2, 0.8))
+    expect_equal(ci, setNames(c(0.2, 0.8), c("lower", "upper")))
   })
 })


### PR DESCRIPTION
## Summary
- normalize bootstrap confidence interval vectors so degenerate results still return named lower/upper bounds
- add unit tests exercising NA, scalar, and single-row bootstrap outputs for maive_prepare_confidence_interval

## Testing
- `Rscript` manual checks for degenerate bootstrap confidence intervals


------
https://chatgpt.com/codex/tasks/task_e_68df66d51a88832a86855ba0453b1ad7