### PR TITLE
Studentize wild bootstrap t-statistics

### DIFF
--- a/tests/testthat/test-boot_studentization.R
+++ b/tests/testthat/test-boot_studentization.R
@@ -1,0 +1,34 @@
+test_that("wild cluster bootstrap uses bootstrap SEs for t statistics", {
+  skip_if_not_installed("clubSandwich")
+
+  set.seed(123)
+  n_clusters <- 8
+  cluster <- rep(seq_len(n_clusters), each = 5)
+  x <- rnorm(length(cluster))
+  cluster_effect <- rnorm(n_clusters, sd = 0.3)
+  y <- 1 + 0.5 * x + cluster_effect[cluster] + rnorm(length(cluster), sd = 0.5)
+
+  data <- data.frame(y = y, x = x, cluster = cluster)
+  model <- lm(y ~ x, data = data)
+
+  boot <- manual_wild_cluster_boot_se(
+    model = model,
+    data = data,
+    cluster_var = "cluster",
+    B = 50,
+    seed = 2024
+  )
+
+  expect_true(!is.null(boot$boot_rep_se))
+  expect_equal(dim(boot$boot_rep_se), dim(boot$boot_coefs))
+
+  base_coefs <- coef(model)
+  for (j in seq_along(base_coefs)) {
+    denom <- boot$boot_rep_se[, j]
+    numer <- boot$boot_coefs[, j] - base_coefs[j]
+    manual_t <- rep(NA_real_, length(numer))
+    ok <- !is.na(denom) & denom != 0
+    manual_t[ok] <- numer[ok] / denom[ok]
+    expect_equal(boot$boot_t_stats[, j], manual_t)
+  }
+})

--- a/tests/testthat/test-maive_build_dummy_matrix.R
+++ b/tests/testthat/test-maive_build_dummy_matrix.R
@@ -1,6 +1,6 @@
 test_that("maive_build_dummy_matrix produces one-hot encoded matrix", {
   values <- c("study_a", "study_b", "study_a", "study_c")
-  result <- MAIVE:::maive_build_dummy_matrix(values)
+  result <- maive:::maive_build_dummy_matrix(values)
 
   expect_true(is.matrix(result))
   expect_equal(nrow(result), length(values))
@@ -14,7 +14,7 @@ test_that("maive_build_dummy_matrix produces one-hot encoded matrix", {
 
 test_that("maive_build_dummy_matrix respects factor levels", {
   factor_values <- factor(c("x", "y", "x"), levels = c("y", "x"))
-  result <- MAIVE:::maive_build_dummy_matrix(factor_values)
+  result <- maive:::maive_build_dummy_matrix(factor_values)
 
   expect_equal(colnames(result), c("studyid.y", "studyid.x"))
   expect_equal(result[, "studyid.y"], c(0, 1, 0))
@@ -28,7 +28,7 @@ test_that("maive_build_dummy_matrix matches varhandle::to.dummy when available",
 
   values <- c("A", "B", "A", "C", "B")
   expected <- varhandle::to.dummy(data.frame(studyid = values), "studyid")
-  actual <- MAIVE:::maive_build_dummy_matrix(values)
+  actual <- maive:::maive_build_dummy_matrix(values)
 
   expect_identical(actual, expected)
 })

--- a/tests/testthat/test-maive_confidence_interval.R
+++ b/tests/testthat/test-maive_confidence_interval.R
@@ -11,7 +11,7 @@ test_that("maive_prepare_confidence_interval handles degenerate bootstrap ci", {
 
   expect_silent({
     ci <- do.call(
-      MAIVE:::maive_prepare_confidence_interval,
+      maive:::maive_prepare_confidence_interval,
       c(base_args, list(boot_result = list(boot_ci = matrix(NA_real_, nrow = 1, ncol = 1))))
     )
     expect_identical(names(ci), c("lower", "upper"))
@@ -20,7 +20,7 @@ test_that("maive_prepare_confidence_interval handles degenerate bootstrap ci", {
 
   expect_silent({
     ci <- do.call(
-      MAIVE:::maive_prepare_confidence_interval,
+      maive:::maive_prepare_confidence_interval,
       c(base_args, list(boot_result = list(boot_ci = matrix(0.5, nrow = 1, ncol = 1))))
     )
     expect_identical(names(ci), c("lower", "upper"))
@@ -31,7 +31,7 @@ test_that("maive_prepare_confidence_interval handles degenerate bootstrap ci", {
     boot_ci <- matrix(c(0.2, 0.8), nrow = 1)
     dimnames(boot_ci) <- list(NULL, NULL)
     ci <- do.call(
-      MAIVE:::maive_prepare_confidence_interval,
+      maive:::maive_prepare_confidence_interval,
       c(base_args, list(boot_result = list(boot_ci = boot_ci)))
     )
     expect_identical(names(ci), c("lower", "upper"))

--- a/tests/testthat/test-maive_first_stage.R
+++ b/tests/testthat/test-maive_first_stage.R
@@ -47,9 +47,9 @@ test_that("Hausman statistic uses difference-in-estimators variance", {
     first_stage = 0
   )
 
-  opts <- MAIVE:::maive_validate_inputs(dat, 1, 0, 1, 2, 0, 1, 0)
-  prepared <- MAIVE:::maive_prepare_data(opts$dat, opts$studylevel)
-  instrumentation <- MAIVE:::maive_compute_variance_instrumentation(
+  opts <- maive:::maive_validate_inputs(dat, 1, 0, 1, 2, 0, 1, 0)
+  prepared <- maive:::maive_prepare_data(opts$dat, opts$studylevel)
+  instrumentation <- maive:::maive_compute_variance_instrumentation(
     prepared$sebs,
     prepared$Ns,
     prepared$g,
@@ -57,15 +57,15 @@ test_that("Hausman statistic uses difference-in-estimators variance", {
     opts$instrument,
     opts$first_stage_type
   )
-  w <- MAIVE:::maive_compute_weights(opts$weight, prepared$sebs, instrumentation$sebs2fit1)
+  w <- maive:::maive_compute_weights(opts$weight, prepared$sebs, instrumentation$sebs2fit1)
   x <- if (opts$instrument == 0L) prepared$sebs else sqrt(instrumentation$sebs2fit1)
   x2 <- if (opts$instrument == 0L) prepared$sebs^2 else instrumentation$sebs2fit1
-  design <- MAIVE:::maive_build_design_matrices(prepared$bs, prepared$sebs, w, x, x2, prepared$D, prepared$dummy)
-  fits <- MAIVE:::maive_fit_models(design)
-  selection <- MAIVE:::maive_select_petpeese(fits, design, opts$alpha_s)
-  sighats <- MAIVE:::maive_compute_sigma_h(fits, design$w, design$sebs)
-  ek <- MAIVE:::maive_fit_ek(selection, design, sighats, opts$method)
-  cfg <- MAIVE:::maive_get_config(opts$method, fits, selection, ek)
+  design <- maive:::maive_build_design_matrices(prepared$bs, prepared$sebs, w, x, x2, prepared$D, prepared$dummy)
+  fits <- maive:::maive_fit_models(design)
+  selection <- maive:::maive_select_petpeese(fits, design, opts$alpha_s)
+  sighats <- maive:::maive_compute_sigma_h(fits, design$w, design$sebs)
+  ek <- maive:::maive_fit_ek(selection, design, sighats, opts$method)
+  cfg <- maive:::maive_get_config(opts$method, fits, selection, ek)
 
   V_iv <- clubSandwich::vcovCR(cfg$maive, cluster = prepared$g, type = opts$type_choice)
   V_ols <- clubSandwich::vcovCR(cfg$std, cluster = prepared$g, type = opts$type_choice)


### PR DESCRIPTION
## Summary
- update the wild cluster bootstrap implementation to recompute clustered standard errors for each resample and use them when forming studentized t-statistics
- guard the bootstrap percentile interval against missing studentized draws and expose the per-replication clustered standard errors for downstream diagnostics
- add a regression test that confirms the stored t-statistics align with the bootstrap coefficients and their corresponding clustered errors

## Testing
- not run (Rscript unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ef40ff2c04832a923037b8f27abc93