### PR TITLE
Align Hausman PET-PEESE weighting with MAIVE

### DIFF
--- a/R/README.Rmd
+++ b/R/README.Rmd
@@ -75,6 +75,9 @@ The function returns:
 
 - The first stage regresses variances on a constant and inverse sample sizes.
 - The Hausman-type test is weighted by the variance of the MAIVE estimator (conservative test).
+- When comparing PET-PEESE variants, MAIVE now fits an auxiliary PET-PEESE using the same
+  weighting scheme as the MAIVE estimator so that the Hausman statistic remains defined even
+  when the selected weighting option differs between estimators.
 - Study fixed effects are demeaned so intercept measures a grand mean.
 - If no study-id column is provided, the program assumes no study-level correlation.
 - The Anderson-Rubin confidence interval follows Keane and Neal (2023).

--- a/R/maivefunction.r
+++ b/R/maivefunction.r
@@ -355,7 +355,7 @@ maive_build_auxiliary_petpeese_matrix <- function(term, design) {
 
 #' @keywords internal
 maive_fit_auxiliary_petpeese <- function(selection, design) {
-  if (isTRUE(selection$quadratic_decision0)) {
+  if (isTRUE(selection$quadratic_decision)) {
     X_aux <- maive_build_auxiliary_petpeese_matrix(design$sebs^2, design)
   } else {
     X_aux <- maive_build_auxiliary_petpeese_matrix(design$sebs, design)

--- a/R/maivefunction.r
+++ b/R/maivefunction.r
@@ -273,8 +273,8 @@ maive_run_pipeline <- function(opts, prepared, instrumentation, w) {
     stop("Failed to identify models for the selected method.")
   }
 
-  beta <- unname(coef(cfg$maive)[1])
-  beta0 <- unname(coef(cfg$std)[1])
+  beta <- unname(coef(hausman_cfg$maive)[1])
+  beta0 <- unname(coef(hausman_cfg$std)[1])
 
   se_ma <- maive_get_intercept_se(cfg$maive, opts$SE, prepared$dat, "g", opts$type_choice)
   se_std <- maive_get_intercept_se(cfg$std, opts$SE, prepared$dat, "g", opts$type_choice)

--- a/README.md
+++ b/README.md
@@ -87,7 +87,9 @@ The function returns:
   sizes.
 - The Hausman-type test compares the MAIVE IV intercept with its OLS counterpart using
   the difference-in-estimators variance under the selected robust/clustered option.
-  estimator (conservative test).
+  estimator (conservative test). When PET-PEESE estimators are compared, MAIVE now fits
+  an auxiliary PET-PEESE with the same weighting scheme as the MAIVE estimator so the
+  Hausman statistic remains available even when weighting choices differ.
 - Study fixed effects are demeaned so intercept measures a grand mean.
 - If no study-id column is provided, the program assumes no study-level
   correlation.

--- a/tests/testthat/test-maive_first_stage.R
+++ b/tests/testthat/test-maive_first_stage.R
@@ -75,3 +75,51 @@ test_that("Hausman statistic uses difference-in-estimators variance", {
 
   expect_equal(as.numeric(result$Hausman), expected_value)
 })
+
+test_that("Hausman PET-PEESE uses MAIVE weights", {
+  dat <- data.frame(
+    bs = c(0.42, 0.5, 0.48, 0.55, 0.46, 0.53),
+    sebs = c(0.18, 0.2, 0.19, 0.21, 0.22, 0.2),
+    Ns = c(80, 95, 90, 85, 88, 92)
+  )
+
+  result <- maive(
+    dat = dat,
+    method = 3,
+    weight = 2,
+    instrument = 1,
+    studylevel = 0,
+    SE = 0,
+    AR = 0,
+    first_stage = 0
+  )
+
+  opts <- maive:::maive_validate_inputs(dat, 3, 2, 1, 0, 0, 0, 0)
+  prepared <- maive:::maive_prepare_data(opts$dat, opts$studylevel)
+  instrumentation <- maive:::maive_compute_variance_instrumentation(
+    prepared$sebs,
+    prepared$Ns,
+    prepared$g,
+    opts$type_choice,
+    opts$instrument,
+    opts$first_stage_type
+  )
+  w <- maive:::maive_compute_weights(opts$weight, prepared$sebs, instrumentation$sebs2fit1)
+  x <- if (opts$instrument == 0L) prepared$sebs else sqrt(instrumentation$sebs2fit1)
+  x2 <- if (opts$instrument == 0L) prepared$sebs^2 else instrumentation$sebs2fit1
+  design <- maive:::maive_build_design_matrices(prepared$bs, prepared$sebs, w, x, x2, prepared$D, prepared$dummy)
+  fits <- maive:::maive_fit_models(design)
+  selection <- maive:::maive_select_petpeese(fits, design, opts$alpha_s)
+  sighats <- maive:::maive_compute_sigma_h(fits, design$w, design$sebs)
+  ek <- maive:::maive_fit_ek(selection, design, sighats, opts$method)
+  cfg <- maive:::maive_get_config(opts$method, fits, selection, ek)
+  hausman_cfg <- maive:::maive_get_hausman_models(opts$method, cfg, selection, design)
+
+  V_iv <- clubSandwich::vcovCR(hausman_cfg$maive, cluster = prepared$g, type = opts$type_choice)
+  V_ols <- clubSandwich::vcovCR(hausman_cfg$std, cluster = prepared$g, type = opts$type_choice)
+  var_diff <- V_iv[1, 1] - V_ols[1, 1]
+  expected <- (coef(hausman_cfg$maive)[1] - coef(hausman_cfg$std)[1])^2 / var_diff
+  expected_value <- as.numeric(round(expected, 3))
+
+  expect_equal(as.numeric(result$Hausman), expected_value)
+})


### PR DESCRIPTION
## Summary
- add an auxiliary PET-PEESE fit that reuses MAIVE weights when computing the Hausman statistic
- ensure the Hausman comparison selects this auxiliary model for PET-PEESE workflows and document the behavior
- extend regression tests to cover the new Hausman weighting logic

## Testing
- `Rscript -e 'devtools::test()'` *(fails: Rscript not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68efab209d20832abe23b3226b62bf47