### PR TITLE
Add study weights weighting option

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: MAIVE
 Type: Package
 Title: Meta Analysis Instrumental Variable Estimator
 Encoding: UTF-8
-Version: 0.0.3.4
+Version: 0.0.3.5
 RoxygenNote: 7.3.3
 Authors@R: 
     c(

--- a/R/README.Rmd
+++ b/R/README.Rmd
@@ -46,7 +46,7 @@ The user needs to specify the following options (with defaults in parentheses):
 | Option       | Description                                  | Values                                              |
 |--------------|----------------------------------------------|-----------------------------------------------------|
 | method       | Meta-analysis method                         | PET=1, PEESE=2, PET-PEESE=3 (default), EK=4        |
-| weighting    | Weighting scheme                            | No weights=0 (default), Weights=1, Adjusted weights=2 |
+| weighting    | Weighting scheme                            | No weights=0 (default), Weights=1, Adjusted weights=2, Study weights=3 |
 | instrumenting| Instrument standard errors                  | No=0, Yes=1 (default)                               |
 | studylevel   | Study-level correlation                     | None=0 (default), Fixed effects=1, Cluster=2       |
 | AR           | Anderson-Rubin confidence interval (available for unweighted and MAIVE-adjusted weights) | No=0 (default), Yes=1                      |
@@ -56,7 +56,7 @@ The user needs to specify the following options (with defaults in parentheses):
 The default MAIVE meta-estimator is MAIVE-PET-PEESE with instrumented standard errors and no weights. However, the user can adjust:
 
 - The meta-analysis method (PET, PEESE, PET-PEESE, EK).
-- The weighting (no weights, inverse-variance weights, or MAIVE-adjusted weights).
+- The weighting (no weights, inverse-variance weights, MAIVE-adjusted weights, or study weights).
 - Instrumentation of standard errors (yes or no).
 - Accounting for study-level correlation (none, fixed effects, or cluster-robust methods).
 

--- a/R/README.md
+++ b/R/README.md
@@ -49,7 +49,7 @@ parentheses):
 | Option | Description | Values |
 |----|----|----|
 | method | Meta-analysis method | PET=1, PEESE=2, PET-PEESE=3 (default), EK=4 |
-| weighting | Weighting scheme | No weights=0 (default), Weights=1, Adjusted weights=2 |
+| weighting | Weighting scheme | No weights=0 (default), Weights=1, Adjusted weights=2, Study weights=3 |
 | instrumenting | Instrument standard errors | No=0, Yes=1 (default) |
 | studylevel | Study-level correlation | None=0 (default), Fixed effects=1, Cluster=2 (default), Fixed effects and cluster = 3 |
 | SE | SE estimator |  CR0 (Huber–White)=0, CR1 (Standard empirical correction)=1, CR2 (Bias-reduced estimator)=2 , wild bootstrap=3 (default)  |
@@ -63,8 +63,8 @@ The default MAIVE meta-estimator is MAIVE-PET-PEESE with instrumented
 standard errors and no weights. Cluster SE, wild bootstrap and Anderson-Rubin confidence interval. However, the user can adjust:
 
 - The meta-analysis method (PET, PEESE, PET-PEESE, EK).
-- The weighting (no weights, inverse-variance weights, or MAIVE-adjusted
-  weights).
+- The weighting (no weights, inverse-variance weights, MAIVE-adjusted
+  weights, or study weights).
 - Instrumentation of standard errors (yes or no).
 - Accounting for study-level correlation (none, fixed effects, cluster-robust methods, or fixed effects and cluster-robust methods).
 - SE estimator (CR0 (Huber–White), CR1 (Standard empirical correction), CR2 (Bias-reduced estimator) , wild bootstrap)

--- a/R/maivefunction.r
+++ b/R/maivefunction.r
@@ -32,7 +32,7 @@ maive_validate_inputs <- function(dat, method, weight, instrument, studylevel, S
   first_stage <- scalar_int(first_stage, "first_stage")
 
   if (!method %in% 1:4) stop("method must be between 1 and 4.")
-  if (!weight %in% 0:2) stop("weight must be 0, 1, or 2.")
+  if (!weight %in% 0:3) stop("weight must be 0, 1, 2, or 3.")
   if (!instrument %in% 0:1) stop("instrument must be 0 or 1.")
   if (!studylevel %in% 0:3) stop("studylevel must be between 0 and 3.")
   if (!SE %in% 0:3) stop("SE must be between 0 and 3.")
@@ -186,13 +186,22 @@ maive_compute_variance_instrumentation <- function(sebs, Ns, g, type_choice, ins
 }
 
 #' @keywords internal
-maive_compute_weights <- function(weight, sebs, sebs2fit1) {
+maive_compute_weights <- function(weight, sebs, sebs2fit1, studyid = NULL) {
   if (weight == 0L) {
     rep(1, length(sebs))
   } else if (weight == 1L) {
     sebs
   } else if (weight == 2L) {
     sqrt(sebs2fit1)
+  } else if (weight == 3L) {
+    if (is.null(studyid)) {
+      studyid <- seq_along(sebs)
+    }
+    if (length(studyid) != length(sebs)) {
+      stop("studyid must align with sebs when using study weights.")
+    }
+    counts <- ave(rep(1, length(studyid)), studyid, FUN = length)
+    1 / counts
   } else {
     stop("Invalid weight option.")
   }
@@ -740,7 +749,7 @@ maive_compute_ar_ci <- function(opts, fits, selection, prepared, invNs, type_cho
 #'
 #' @param dat Data frame with columns bs, sebs, Ns, study_id (optional).
 #' @param method 1 FAT-PET, 2 PEESE, 3 PET-PEESE, 4 EK.
-#' @param weight 0 no weights, 1 standard weights, 2 MAIVE adjusted weights.
+#' @param weight 0 no weights, 1 standard weights, 2 MAIVE adjusted weights, 3 study weights.
 #' @param instrument 1 yes, 0 no.
 #' @param studylevel Correlation at study level: 0 none, 1 fixed effects, 2 cluster.
 #' @param SE SE estimator: 0 CR0 (Huber–White), 1 CR1 (Standard empirical correction),
@@ -786,7 +795,7 @@ maive <- function(dat, method, weight, instrument, studylevel, SE, AR, first_sta
   prepared <- maive_prepare_data(opts$dat, opts$studylevel)
   instrumentation <- maive_compute_variance_instrumentation(prepared$sebs, prepared$Ns, prepared$g, opts$type_choice, opts$instrument, opts$first_stage_type)
 
-  w <- maive_compute_weights(opts$weight, prepared$sebs, instrumentation$sebs2fit1)
+  w <- maive_compute_weights(opts$weight, prepared$sebs, instrumentation$sebs2fit1, prepared$studyid)
 
   maive_run_pipeline(opts, prepared, instrumentation, w)
 }
@@ -823,7 +832,7 @@ waive <- function(dat, method, weight, instrument, studylevel, SE, AR, first_sta
   prepared <- maive_prepare_data(opts$dat, opts$studylevel)
   instrumentation <- maive_compute_variance_instrumentation(prepared$sebs, prepared$Ns, prepared$g, opts$type_choice, opts$instrument, opts$first_stage_type)
 
-  base_w <- maive_compute_weights(opts$weight, prepared$sebs, instrumentation$sebs2fit1)
+  base_w <- maive_compute_weights(opts$weight, prepared$sebs, instrumentation$sebs2fit1, prepared$studyid)
   decay_weights <- maive_compute_waive_weights(instrumentation$first_stage_model)
 
   if (opts$weight == 0L) {

--- a/man/maive.Rd
+++ b/man/maive.Rd
@@ -11,7 +11,7 @@ maive(dat, method, weight, instrument, studylevel, SE, AR, first_stage = 0L)
 
 \item{method}{1 FAT-PET, 2 PEESE, 3 PET-PEESE, 4 EK.}
 
-\item{weight}{0 no weights, 1 standard weights, 2 MAIVE adjusted weights.}
+\item{weight}{0 no weights, 1 standard weights, 2 MAIVE adjusted weights, 3 study weights.}
 
 \item{instrument}{1 yes, 0 no.}
 

--- a/readme copy.txt
+++ b/readme copy.txt
@@ -44,7 +44,7 @@ The user needs to specify the following options (with defaults in parentheses):
 | Option       | Description                                  | Values                                              |
 |--------------|----------------------------------------------|-----------------------------------------------------|
 | method       | Meta-analysis method                         | PET=1, PEESE=2, PET-PEESE=3 (default), EK=4        |
-| weighting    | Weighting scheme                            | No weights=0 (default), Weights=1, Adjusted weights=2 |
+| weighting    | Weighting scheme                            | No weights=0 (default), Weights=1, Adjusted weights=2, Study weights=3 |
 | instrumenting| Instrument standard errors                  | No=0, Yes=1 (default)                               |
 | studylevel   | Study-level correlation                     | None=0 (default), Fixed effects=1, Cluster=2       |
 | AR           | Anderson-Rubin confidence interval (available for unweighted and MAIVE-adjusted weights) | No=0 (default), Yes=1                      |

--- a/tests/testthat/test-maive_first_stage.R
+++ b/tests/testthat/test-maive_first_stage.R
@@ -57,7 +57,7 @@ test_that("Hausman statistic uses difference-in-estimators variance", {
     opts$instrument,
     opts$first_stage_type
   )
-  w <- MAIVE:::maive_compute_weights(opts$weight, prepared$sebs, instrumentation$sebs2fit1)
+  w <- MAIVE:::maive_compute_weights(opts$weight, prepared$sebs, instrumentation$sebs2fit1, prepared$studyid)
   x <- if (opts$instrument == 0L) prepared$sebs else sqrt(instrumentation$sebs2fit1)
   x2 <- if (opts$instrument == 0L) prepared$sebs^2 else instrumentation$sebs2fit1
   design <- MAIVE:::maive_build_design_matrices(prepared$bs, prepared$sebs, w, x, x2, prepared$D, prepared$dummy)
@@ -104,7 +104,7 @@ test_that("Hausman PET-PEESE uses MAIVE weights", {
     opts$instrument,
     opts$first_stage_type
   )
-  w <- MAIVE:::maive_compute_weights(opts$weight, prepared$sebs, instrumentation$sebs2fit1)
+  w <- MAIVE:::maive_compute_weights(opts$weight, prepared$sebs, instrumentation$sebs2fit1, prepared$studyid)
   x <- if (opts$instrument == 0L) prepared$sebs else sqrt(instrumentation$sebs2fit1)
   x2 <- if (opts$instrument == 0L) prepared$sebs^2 else instrumentation$sebs2fit1
   design <- MAIVE:::maive_build_design_matrices(prepared$bs, prepared$sebs, w, x, x2, prepared$D, prepared$dummy)

--- a/tests/testthat/test-study-weights.R
+++ b/tests/testthat/test-study-weights.R
@@ -1,0 +1,26 @@
+test_that("Study weights give each study equal total weight", {
+  dat <- data.frame(
+    bs = c(0.4, 0.5, 0.45, 0.55, 0.47, 0.52),
+    sebs = c(0.2, 0.19, 0.21, 0.18, 0.22, 0.2),
+    Ns = c(80, 85, 90, 95, 88, 92),
+    study_id = c("A", "A", "B", "B", "B", "C")
+  )
+
+  opts <- MAIVE:::maive_validate_inputs(dat, method = 1, weight = 3, instrument = 1, studylevel = 2, SE = 0, AR = 0, first_stage = 0)
+  prepared <- MAIVE:::maive_prepare_data(opts$dat, opts$studylevel)
+  instrumentation <- MAIVE:::maive_compute_variance_instrumentation(
+    prepared$sebs,
+    prepared$Ns,
+    prepared$g,
+    opts$type_choice,
+    opts$instrument,
+    opts$first_stage_type
+  )
+
+  w <- MAIVE:::maive_compute_weights(opts$weight, prepared$sebs, instrumentation$sebs2fit1, prepared$studyid)
+
+  expect_equal(w, c(rep(1 / 2, 2), rep(1 / 3, 3), 1))
+
+  totals <- tapply(w, prepared$studyid, sum)
+  expect_true(all(abs(totals - 1) < 1e-12))
+})


### PR DESCRIPTION
## Summary
- add a study-based weighting mode that assigns 1/n_j to each estimate
- ensure MAIVE and WAIVE pass study identifiers into the weighting pipeline
- update documentation and tests to cover the new study weights option

## Testing
- R -q -e "testthat::test_dir('tests/testthat')" *(fails: command not found: R)*

------
https://chatgpt.com/codex/tasks/task_e_690b07b12df4832aad3ae9893ecea01f